### PR TITLE
Fix undefined bold_italic

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -31,6 +31,7 @@ if !exists('g:one_allow_italics')
 endif
 
 let s:italic = ''
+let s:bold_italic = ''
 if g:one_allow_italics == 1
   let s:italic = 'italic'
   let s:bold_italic = 'bold,italic'


### PR DESCRIPTION
Fixes this:

```
E5113: Error while calling lua chunk: /home/mario/.config/nvim/lua/config/themes/vim-one.lua:3: Vim(call):E121: Undefined variable: s:bold_italic
Error detected while processing /home/mario/.local/share/nvim/site/pack/packer/start/vim-one/colors/one.vim:
line  744:
E121: Undefined variable: s:bold_italic
E116: Invalid arguments for function <SNR>10_X
Press ENTER or type command to continue
```